### PR TITLE
switch URL to correct repo and tag

### DIFF
--- a/REPRODUCIBLE_BUILDS.md
+++ b/REPRODUCIBLE_BUILDS.md
@@ -12,9 +12,9 @@ Download and install [Docker](https://www.docker.com/).
 3. Checkout the Tag that corresponds to the version of your app (e.g., 1.0.0)
 
 ```shell
-git clone https://github.com/admin-ch/CovidCertificate-App-Android.git ~/CovidCertificate-App-Android
+git clone https://github.com/BRZ-GmbH/CovidCertificate-App-Android.git ~/CovidCertificate-App-Android
 cd ~/CovidCertificate-App-Android
-git checkout 1.0.0
+git checkout v1.0.0-210701.9-wallet
 ```
 
 ## Wallet App


### PR DESCRIPTION
There are still open issues linking to likely invalid resources:
https://github.com/BRZ-GmbH/CovidCertificate-App-Android/blob/main/verifier/build.gradle#L51
https://github.com/BRZ-GmbH/CovidCertificate-App-Android/blob/main/verifier/build.gradle#L103